### PR TITLE
fix: update repository URLs from lroolle to thevibeworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repository contains Claude Code documentation and resources for **learning about [Claude Code](https://claude.ai/code)**
 
-![Claude Code in Action](https://raw.githubusercontent.com/lroolle/claude-code-docs/main/screenshot.png)
+![Claude Code in Action](https://raw.githubusercontent.com/thevibeworks/claude-code-docs/main/screenshot.png)
 
 
 ## Quick Start for How to Use Claude Code
@@ -20,11 +20,11 @@ npm install -g @anthropic-ai/claude-code
 ### Getting Started
 
 
-> **GitHub Repository**: https://github.com/lroolle/claude-code-docs
+> **GitHub Repository**: https://github.com/thevibeworks/claude-code-docs
 
 1. **Clone this repository**:
    ```bash
-   git clone https://github.com/lroolle/claude-code-docs
+   git clone https://github.com/thevibeworks/claude-code-docs
    cd claude-code-docs
    ```
 

--- a/intro-post.md
+++ b/intro-post.md
@@ -45,7 +45,7 @@ Stop following tutorials that lead nowhere. Use Claude Code to build actual soft
 npm install -g @anthropic-ai/claude-code
 
 # Clone the learning repository
-git clone https://github.com/lroolle/claude-code-docs
+git clone https://github.com/thevibeworks/claude-code-docs
 cd claude-code-docs
 
 # Start your first vibe coding session


### PR DESCRIPTION
Fixes #176

Updated repository URLs in documentation files to point to the correct repository:

- README.md: Fixed screenshot URL, repository reference, and git clone command
- intro-post.md: Fixed git clone command

All URLs now correctly point to thevibeworks/claude-code-docs instead of lroolle/claude-code-docs.

Generated with [Claude Code](https://claude.ai/code)