### PR TITLE
workflow: add default barkme icon

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -83,6 +83,7 @@ jobs:
                     "BARK_DEVICES": "${{ secrets.BARK_DEVICES }}",
                     "BARK_SERVER": "${{ secrets.BARK_SERVER }}",
                     "BARK_GROUP": "Claude YOLO",
+                    "BARK_ICON": "https://avatars.githubusercontent.com/in/1452392",
                     "BARK_RETRY": "3",
                     "BARK_ASYNC": "false"
                   }


### PR DESCRIPTION
## Summary
• Add BARK_ICON env var to use default GitHub app icon for notifications

🤖 Generated with [Claude Code](https://claude.ai/code)