### PR TITLE
refactor: switch workflows to claude-code-action@main

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -63,14 +63,14 @@ jobs:
         if: |
           !contains(github.event.pull_request.title, '[skip-review]') &&
           !contains(github.event.pull_request.title, '[WIP]')
-        uses: thevibeworks/claude-code-action@feat/allow-bot-actor
+        uses: anthropics/claude-code-action@main
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
           model: "claude-sonnet-4-20250514"
-          allow_bot_actor: true
+          allowed_bots: "claude-yolo[bot],github-actions[bot]"
           allowed_tools: "Bash(gh pr:*),Bash(git:*),Bash(gh issue:*),Bash(gh release:*),Bash(npm:*),Bash(ls:*),Bash(cat:*),Bash(grep:*),Bash(./scripts/fetchccdocs.sh:*),Bash(jq:*),mcp__barkme__notify"
           mcp_config: |
             {

--- a/.github/workflows/fetch-claude-docs.yml
+++ b/.github/workflows/fetch-claude-docs.yml
@@ -136,18 +136,18 @@ jobs:
               --title "docs: Claude Code v{version} - {key feature}" \
               --body "## Night shift report
               
-WHY THIS MATTERS: {reason humans should care}
+              WHY THIS MATTERS: {reason humans should care}
               
-WHAT CHANGED: {brief summary}
+              WHAT CHANGED: {brief summary}
               
-HIGHLIGHTS:
+              HIGHLIGHTS:
               - {most interesting change}
               - {second most interesting}
               
----
-*Created by night-shift claude-yolo at 23:45 Pacific*
-*After Anthropic engineers went home*
-*Day-shift claude-yolo will review and merge this in the morning*")
+              ---
+              *Created by night-shift claude-yolo at 23:45 Pacific*
+              *After Anthropic engineers went home*
+              *Day-shift claude-yolo will review and merge this in the morning*")
             
             # Always barkme when PR created (simple notification)
             # Use mcp__barkme__notify with concise message

--- a/.github/workflows/fetch-claude-docs.yml
+++ b/.github/workflows/fetch-claude-docs.yml
@@ -41,14 +41,6 @@ jobs:
       - name: Export token for subsequent steps
         run: echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
 
-      - name: Token sanity check
-        run: |
-          echo "=== Token Permission Info ==="
-          gh api repos/${{ github.repository }} --jq '.permissions'
-          echo "::warning::repo.permissions is not reliable for App tokens (always shows push:false)"
-          echo "App token configured with: contents:write, pull_requests:write, issues:write"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -59,14 +51,15 @@ jobs:
         run: ./scripts/fetchccdocs.sh --format md
 
       - name: Claude handles everything
-        uses: thevibeworks/claude-code-action@feat/allow-bot-actor
+        uses: anthropics/claude-code-action@main
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
           model: "claude-sonnet-4-20250514"
-          allow_bot_actor: true
+          mode: "agent"
+          allowed_bots: "claude-yolo[bot]"
           allowed_tools: "Bash(gh pr:*),Bash(git:*),Bash(npm:*),Bash(jq:*),Bash(date:*),mcp__barkme__notify"
           mcp_config: |
             {


### PR DESCRIPTION
## Summary
- Switch from custom fork to official claude-code-action@main
- Use built-in `allowed_bots` parameter for bot authentication 
- Clean up unnecessary token permission checks

## Changes
- Updated both workflows to use `anthropics/claude-code-action@main`
- Replaced deprecated `allow_bot_actor: true` with `allowed_bots` parameter
- Configured fetch-docs workflow with `mode: "agent"` for automation
- Removed redundant token permission sanity check

## Test plan
- [ ] Workflows trigger correctly on schedule/dispatch
- [ ] Bot authentication works with allowed_bots parameter
- [ ] Agent mode properly handles workflow_dispatch events

🤖 Generated with [Claude Code](https://claude.ai/code)