### PR TITLE
fix: workflow PR creation for AI maintainer

### DIFF
--- a/.github/workflows/fetch-claude-docs.yml
+++ b/.github/workflows/fetch-claude-docs.yml
@@ -2,16 +2,8 @@ name: Fetch Claude Code Docs
 
 on:
   schedule:
-    # Daily at 23:45 Pacific (Anthropic's timezone)
-    # 23:45 PST = 07:45 UTC (winter)
-    # 23:45 PDT = 06:45 UTC (summer)
-    # Using 07:45 UTC as compromise
-    - cron: "45 7 * * *"
-    # Daily at 19:00 Los Angeles time
-    # 19:00 PST = 03:00 UTC (winter)
-    # 19:00 PDT = 02:00 UTC (summer)
-    # Using 03:00 UTC as compromise
-    - cron: "0 3 * * *"
+    # Every 6 hours: 00:00, 06:00, 12:00, 18:00 UTC
+    - cron: "0 */6 * * *"
   workflow_dispatch: # Allow manual trigger
 
 jobs:
@@ -130,28 +122,8 @@ jobs:
 
             **For meaningful changes (PR needed)**:
             ```bash
-            git add .
-            git commit -m "docs: {explain WHY this matters}"
-            PR_URL=$(gh pr create \
-              --title "docs: Claude Code v{version} - {key feature}" \
-              --body "## Night shift report
-              
-              WHY THIS MATTERS: {reason humans should care}
-              
-              WHAT CHANGED: {brief summary}
-              
-              HIGHLIGHTS:
-              - {most interesting change}
-              - {second most interesting}
-              
-              ---
-              *Created by night-shift claude-yolo at 23:45 Pacific*
-              *After Anthropic engineers went home*
-              *Day-shift claude-yolo will review and merge this in the morning*")
-            
-            # Always barkme when PR created (simple notification)
-            # Use mcp__barkme__notify with concise message
-            # Example: "📦 Claude Code v1.0.77" with PR URL
+            PR_URL=$(./scripts/create-docs-pr.sh "{key feature}" "{why it matters}" "{version}")
+            # Barkme notification with PR URL
             ```
 
             **For minor changes (direct commit)**:

--- a/scripts/create-docs-pr.sh
+++ b/scripts/create-docs-pr.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ $# -lt 3 ]; then
+    echo "Usage: $0 <title> <description> <version>"
+    echo "Example: $0 'SDK improvements' 'Request cancellation support' '1.0.83'"
+    exit 1
+fi
+
+TITLE="$1"
+DESCRIPTION="$2"
+VERSION="$3"
+
+if git diff --quiet && git diff --cached --quiet; then
+    echo "No changes to commit"
+    exit 0
+fi
+
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+    echo "Error: Must be on main branch. Current: $CURRENT_BRANCH"
+    exit 1
+fi
+
+TIMESTAMP=$(date +%Y%m%d-%H%M)
+BRANCH_NAME="docs/claude-code-v${VERSION}-${TIMESTAMP}"
+
+git checkout -b "$BRANCH_NAME" || exit 1
+
+git add .
+git commit -m "docs: Claude Code v${VERSION} - ${TITLE}
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+
+git push -u origin HEAD || exit 1
+
+PR_URL=$(gh pr create \
+  --title "docs: Claude Code v${VERSION} - ${TITLE}" \
+  --body "## Night shift report
+
+WHY THIS MATTERS: ${DESCRIPTION}
+
+WHAT CHANGED: Version bump to v${VERSION}
+
+HIGHLIGHTS:
+- ${DESCRIPTION}
+
+---
+*Created by night-shift claude-yolo*
+*After Anthropic engineers went home*
+*Day-shift claude-yolo will review and merge this in the morning*")
+
+echo "$PR_URL"


### PR DESCRIPTION
## Fix AI maintainer PR creation failures

The AI maintainer was failing with: `aborted: you must first push the current branch to a remote`

### Changes
- Add explicit branch push before PR creation
- Create helper script for one-shot PR creation  
- Simplify workflow instructions to single path
- Add proper error handling and branch validation
- Update schedule from daily to every 6 hours

### Helper Script
New `scripts/create-docs-pr.sh` handles:
- Branch creation from main
- Commit with proper message
- Push to remote
- PR creation with formatted body

This should prevent the AI maintainer from getting stuck.

🤖 Generated with [Claude Code](https://claude.ai/code)