### PR TITLE
Point to the correct VS Code extension name.

### DIFF
--- a/content/claude-code-docs/devcontainer.md
+++ b/content/claude-code-docs/devcontainer.md
@@ -24,10 +24,10 @@ The container's enhanced security measures (isolation and firewall rules) allow 
 
 ## Getting started in 4 steps
 
-1. Install VS Code and the Remote - Containers extension
+1. Install VS Code and the Dev Containers extension
 2. Clone the [Claude Code reference implementation](https://github.com/anthropics/claude-code/tree/main/.devcontainer) repository
 3. Open the repository in VS Code
-4. When prompted, click "Reopen in Container" (or use Command Palette: Cmd+Shift+P → "Remote-Containers: Reopen in Container")
+4. When prompted, click "Reopen in Container" (or use Command Palette: Cmd+Shift+P → "Dev Containers: Reopen in Container")
 
 ## Configuration breakdown
 


### PR DESCRIPTION
I think the extension was renamed to "Dev Containers"