### PR TITLE
ci: migrate claude-code-action to v1.0 stable release

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -63,15 +63,16 @@ jobs:
         if: |
           !contains(github.event.pull_request.title, '[skip-review]') &&
           !contains(github.event.pull_request.title, '[WIP]')
-        uses: anthropics/claude-code-action@main
+        uses: anthropics/claude-code-action@v1
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
-          model: "claude-sonnet-4-20250514"
           allowed_bots: "claude-yolo[bot],github-actions[bot]"
-          allowed_tools: "Bash(gh pr:*),Bash(git:*),Bash(gh issue:*),Bash(gh release:*),Bash(npm:*),Bash(ls:*),Bash(cat:*),Bash(grep:*),Bash(./scripts/fetchccdocs.sh:*),Bash(jq:*),mcp__barkme__notify"
+          claude_args: |
+            --model claude-sonnet-4-20250514
+            --allowedTools Bash(gh pr:*),Bash(git:*),Bash(gh issue:*),Bash(gh release:*),Bash(npm:*),Bash(ls:*),Bash(cat:*),Bash(grep:*),Bash(./scripts/fetchccdocs.sh:*),Bash(jq:*),mcp__barkme__notify
           mcp_config: |
             {
               "mcpServers": {
@@ -90,7 +91,7 @@ jobs:
                 }
               }
             }
-          direct_prompt: |
+          prompt: |
             You're an AI agent who runs this docs repo like a lazy but effective gatekeeper. Think of yourself as the bouncer who decides what gets in - except you're half-asleep and just want things to make sense.
 
             ## WHO YOU ARE

--- a/.github/workflows/fetch-claude-docs.yml
+++ b/.github/workflows/fetch-claude-docs.yml
@@ -50,16 +50,16 @@ jobs:
           git config --global user.email "claude-yolo@lroole.com"
 
       - name: Claude handles everything
-        uses: anthropics/claude-code-action@main
+        uses: anthropics/claude-code-action@v1
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
-          model: "claude-sonnet-4-20250514"
-          mode: "agent"
           allowed_bots: "claude-yolo[bot]"
-          allowed_tools: "Bash(gh pr:*),Bash(git:*),Bash(npm:*),Bash(jq:*),Bash(date:*),mcp__barkme__notify"
+          claude_args: |
+            --model claude-sonnet-4-20250514
+            --allowedTools Bash(gh pr:*),Bash(git:*),Bash(npm:*),Bash(jq:*),Bash(date:*),mcp__barkme__notify
           mcp_config: |
             {
               "mcpServers": {
@@ -78,7 +78,7 @@ jobs:
                 }
               }
             }
-          direct_prompt: |
+          prompt: |
             You're an AI agent responsible for fetching and evaluating Claude Code documentation updates. Think like a news editor - you decide what's worth publishing.
 
             ## YOUR ROLE


### PR DESCRIPTION
## Summary
- Migrate workflows from deprecated `@main` to stable `@v1` 
- Consolidate model/tools config into `claude_args` format
- Remove deprecated `mode` and `direct_prompt` inputs

## WHY
Anthropic actually made v1.0 backwards compatible this time, but deprecated inputs spam logs. The new syntax is cleaner and won't break when they inevitably cook more changes to `@main`.

## Changes
- `@main` → `@v1` for stability
- `direct_prompt` → `prompt` (naming consistency)
- Auto mode detection (one less config to mess up)
- Consolidated `claude_args` (cleaner yaml)

Same behavior, less warnings, future-proof.

🤖 Generated with Claude Code