### PR TITLE
fix: add metadata read permission for GitHub App auth

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -43,6 +43,7 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
           permission-issues: write
+          permission-metadata: read
 
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
claude-code-action v1 needs user info for git config but our GitHub App token was missing metadata:read permission. 403 on /user endpoint.

WHY: automation mode tries to configure git auth, needs user details.