### PR TITLE
fix: remove cache config for inline script deps

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -51,9 +51,7 @@ jobs:
       - name: Install uv and Python 3.14t
         uses: astral-sh/setup-uv@v5
         with:
-          enable-cache: true
           python-version: "3.14t"
-          cache-dependency-glob: "scripts/fetchccdocs.py"
 
       - name: Setup GitHub CLI and Git
         run: |

--- a/.github/workflows/fetch-claude-docs.yml
+++ b/.github/workflows/fetch-claude-docs.yml
@@ -38,9 +38,7 @@ jobs:
       - name: Install uv and Python 3.14t
         uses: astral-sh/setup-uv@v5
         with:
-          enable-cache: true
           python-version: "3.14t"
-          cache-dependency-glob: "scripts/fetchccdocs.py"
 
       - name: Fetch Claude Code docs
         run: uv run scripts/fetchccdocs.py --format md


### PR DESCRIPTION
Fixes workflow cache error from #402.

Inline script dependencies (PEP 723) don't use standard pip cache path. uv downloads deps instantly (~1sec) so cache not needed.

Error was:
  Cache path /home/runner/work/_temp/setup-uv-cache does not exist