### PR TITLE
chore: align schedule with hn-digest

### DIFF
--- a/.github/workflows/fetch-claude-docs.yml
+++ b/.github/workflows/fetch-claude-docs.yml
@@ -3,7 +3,7 @@ name: Fetch Claude Code Docs
 on:
   schedule:
     # Every 6 hours: 00:00, 06:00, 12:00, 18:00 UTC
-    - cron: "0 */6 * * *"
+    - cron: "0 1,6,11,16 * * *"
   workflow_dispatch: # Allow manual trigger
 
 jobs:


### PR DESCRIPTION
Sync fetch-claude-docs schedule with hn-digest to consolidate Claude quota usage.

**Before:** `0 */6 * * *` (00:00, 06:00, 12:00, 18:00 UTC)
**After:** `0 1,6,11,16 * * *` (01:00, 06:00, 11:00, 16:00 UTC)

Both workflows now run at the same times for predictable quota reset cycles.