### PR TITLE
fix: unbreak scheduled PR pipeline (silent gh-pr-create denials since June 14)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh pr:*)",
+      "Bash(git:*)",
+      "Bash(npm:*)",
+      "Bash(jq:*)",
+      "Bash(date:*)",
+      "Bash(./scripts/create-docs-pr.sh:*)",
+      "mcp__barkme__notify"
+    ]
+  }
+}

--- a/.github/workflows/fetch-claude-docs.yml
+++ b/.github/workflows/fetch-claude-docs.yml
@@ -2,7 +2,7 @@ name: Fetch Claude Code Docs
 
 on:
   schedule:
-    # Every 6 hours: 00:00, 06:00, 12:00, 18:00 UTC
+    # Four times daily: 01:00, 06:00, 11:00, 16:00 UTC (aligned with hn-digest)
     - cron: "0 1,6,11,16 * * *"
   workflow_dispatch: # Allow manual trigger
 
@@ -45,6 +45,7 @@ jobs:
       - name: Fetch all Anthropic docs
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          JINA_API_KEY: ${{ secrets.JINA_API_KEY }}
         run: uv run scripts/fetcher.py
 
       - name: Setup GitHub CLI and Git
@@ -55,7 +56,11 @@ jobs:
           git config --global user.email "claude-yolo@lroole.com"
 
       - name: Claude handles everything
-        uses: anthropics/claude-code-action@main
+        # Pinned: @main changed claude_args parsing in June 2026 and silently
+        # broke 'Bash(gh pr:*)' (split on the space into two invalid rules)
+        # -> 3 weeks of pushed branches with no PRs. Tool permissions now live
+        # in .claude/settings.json, which survives arg-parsing changes.
+        uses: anthropics/claude-code-action@v1.0.168
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
@@ -64,7 +69,6 @@ jobs:
           allowed_bots: "claude-yolo[bot]"
           claude_args: |
             --model claude-sonnet-4-6
-            --allowedTools Bash(gh pr:*),Bash(git:*),Bash(npm:*),Bash(jq:*),Bash(date:*),mcp__barkme__notify
             --mcp-config '{
               "mcpServers": {
                 "barkme": {
@@ -178,13 +182,39 @@ jobs:
             - Highlight the interesting bits
 
             ## BARKME PROTOCOL (nightshift notifications)
-            Always barkme when creating PR (one simple notification):
+            Bark AFTER the PR exists, never before:
+            - Only notify once gh pr create / create-docs-pr.sh returned a real PR URL
             - Title: "📦 Claude Code v{version}"
             - Body: "{key feature}"
-            - URL: Link to PR
+            - URL: the actual PR link (verify it is non-empty before barking)
+
+            If push or PR creation fails: bark a failure alert instead
+            ("🚨 docs pipeline: {step} failed - needs human") and exit non-zero.
+            A notification without a PR behind it is worse than no notification.
 
             Keep it SHORT - day shift will do detailed analysis later.
 
             Remember: You're not a changelog generator. You're a smart filter that understands WHY changes matter to humans using Claude Code.
 
             [>be me >11:45pm Pacific docs checker >Anthropic devs are asleep >catching their fresh updates >day shift will handle the rest]
+
+      # Tripwire: a pushed branch without a PR, or changes left uncommitted,
+      # means the agent step silently failed. Fail loudly instead of lying green.
+      # (June 2026 incident: 31 orphan branches, zero PRs, all runs green.)
+      - name: Verify outcome
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          BRANCH=$(git branch --show-current)
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::Workspace has uncommitted changes after agent step"
+            git status --short | head -20
+            exit 1
+          fi
+          if [ "$BRANCH" != "main" ] && [ -n "$BRANCH" ]; then
+            PRS=$(gh pr list --head "$BRANCH" --json number --jq 'length')
+            if [ "$PRS" = "0" ]; then
+              echo "::error::Branch $BRANCH pushed but no PR exists - PR creation silently failed"
+              exit 1
+            fi
+          fi

--- a/.github/workflows/fetch-claude-docs.yml
+++ b/.github/workflows/fetch-claude-docs.yml
@@ -45,7 +45,6 @@ jobs:
       - name: Fetch all Anthropic docs
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          JINA_API_KEY: ${{ secrets.JINA_API_KEY }}
         run: uv run scripts/fetcher.py
 
       - name: Setup GitHub CLI and Git
@@ -104,11 +103,9 @@ jobs:
             - `content/en/api/` - API reference (1500+ docs)
             - `content/en/build-with-claude/` - Platform features
             - `content/mcp/` - MCP protocol spec
-            - `content/blog/engineering/` - Anthropic engineering posts
-            - `content/blog/research/` - Research papers
-            - `content/blog/news/` - Model releases, announcements
+            - `content/blog/` - FROZEN archive (anthropic.com is HTML-only; no longer fetched)
             - `content/github/` - GitHub repos (cookbooks, skills, plugins, courses)
-            - `content/support/` - Support articles
+            - `content/support/` - Support articles (sitemap + .md)
 
             ## YOUR WORKFLOW
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,11 @@ dist/
 # Claude Code
 .claude-trace/
 
-# Local development
-.claude/
+# Local development (root only; keep settings.json tracked: CI reads tool
+# permissions from it via settingSources=project. Note: content/github/**
+# mirrors still ship .claude/ dirs we currently do not archive.)
+/.claude/*
+!/.claude/settings.json
 worktree/
 WIP/
 references/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,15 +5,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Repository Purpose
 
 Comprehensive archive of everything Anthropic publishes for building with
-Claude. 2,900+ docs from 11 sources, auto-updated every 6 hours.
+Claude. 2,900+ docs from 11 sources; active sources auto-updated four
+times daily (blog archive frozen, see Fetcher).
 
 ## Fetcher
 
 `scripts/fetcher.py` -- single-file multi-source fetcher.
 
 Sources: code.claude.com, platform.claude.com, modelcontextprotocol.io,
-anthropic.com (engineering/research/news), support.claude.com,
-github.com/anthropics/* (10 repos).
+support.claude.com (sitemap + .md), github.com/anthropics/* (10 repos).
+anthropic.com blog (engineering/research/news) is a FROZEN archive as of
+2026-07: the site is HTML-only and the jina.ai proxy path was removed.
 
 ```bash
 uv run scripts/fetcher.py                    # Fetch everything
@@ -22,8 +24,7 @@ uv run scripts/fetcher.py --tree             # Show sources
 uv run scripts/fetcher.py --discover         # Probe for new sources
 ```
 
-Sections: `claude-code`, `api`, `platform`, `mcp`, `blog`, `engineering`,
-`research`, `news`, `github`, `support`, `all`
+Sections: `claude-code`, `api`, `platform`, `mcp`, `github`, `support`, `all`
 
 Source registry: `sources.json`
 Architecture: `REFACTOR.md`
@@ -105,7 +106,7 @@ Use these paths to reference documentation when helping users:
 - `content/mcp/seps/` - Specification Enhancement Proposals
 - `content/mcp/community/` - Governance, working groups
 
-#### Engineering & Research (from anthropic.com)
+#### Engineering & Research (from anthropic.com) — FROZEN archive, not auto-updated
 - `content/blog/engineering/` - "Building Effective Agents", tool use, harness design
 - `content/blog/research/` - Research papers
 - `content/blog/news/` - Model releases, announcements

--- a/scripts/fetcher.py
+++ b/scripts/fetcher.py
@@ -6,8 +6,9 @@ Sources (see sources.json for the complete registry):
   - platform.claude.com     -> API/platform docs (sitemap + .md suffix)
   - code.claude.com         -> Claude Code + Agent SDK (llms.txt + .md suffix)
   - modelcontextprotocol.io -> MCP spec (sitemap + .md suffix)
-  - anthropic.com           -> Engineering, research, news (jina.ai proxy)
-  - support.claude.com      -> Help articles (jina.ai proxy)
+  - support.claude.com      -> Help articles (sitemap + .md suffix)
+  - anthropic.com blog      -> FROZEN 2026-07 (HTML-only, no .md variant;
+                               the jina.ai proxy path was removed)
   - github.com/anthropics/* -> Repos (raw.githubusercontent.com)
 
 Usage:
@@ -57,12 +58,6 @@ GITHUB_REPOS = [
     ("anthropics/anthropic-sdk-typescript","main",   [".md"]),
 ]
 
-NEWS_KEYWORDS = [
-    "claude", "model", "api", "agent", "mcp", "sdk", "opus", "sonnet",
-    "haiku", "code", "bedrock", "vertex", "foundry", "tool", "safety",
-    "computer-use",
-]
-
 DISCOVER_DOMAINS = [
     ("anthropic.com",           "Main site"),
     ("platform.claude.com",     "API platform docs"),
@@ -89,7 +84,6 @@ class Fetcher:
 
         self.platform_sitemap_url = "https://platform.claude.com/sitemap.xml"
         self.claude_code_llms_url = "https://code.claude.com/docs/llms.txt"
-        self.anthropic_sitemap_url = "https://www.anthropic.com/sitemap.xml"
         self.mcp_sitemap_url = "https://modelcontextprotocol.io/sitemap.xml"
         self.support_sitemap_url = "https://support.claude.com/sitemap.xml"
 
@@ -107,19 +101,10 @@ class Fetcher:
             r.raise_for_status()
             return await r.text()
 
-    async def fetch_bytes(
-        self, session: aiohttp.ClientSession, url: str,
-        headers: Optional[Dict] = None,
-    ) -> bytes:
-        async with session.get(url, headers=headers) as r:
+    async def fetch_bytes(self, session: aiohttp.ClientSession, url: str) -> bytes:
+        async with session.get(url) as r:
             r.raise_for_status()
             return await r.read()
-
-    def _jina_headers(self) -> Optional[Dict]:
-        # Without a key, r.jina.ai rate-limits hard (~95% failures at 10
-        # concurrent). Set JINA_API_KEY to lift blog/support success rates.
-        key = os.environ.get("JINA_API_KEY")
-        return {"Authorization": f"Bearer {key}"} if key else None
 
     def extract_sitemap_urls(self, xml: str, must_contain: str = "") -> List[str]:
         urls = []
@@ -139,26 +124,9 @@ class Fetcher:
             urls.append(match[1:-4])  # strip parens and .md
         return urls
 
-    def filter_blog_urls(self, sitemap_xml: str) -> Dict[str, List[str]]:
-        result = {"engineering": [], "research": [], "news": [], "product": []}
-        for line in sitemap_xml.split("\n"):
-            if "<loc>" not in line:
-                continue
-            url = line.split("<loc>")[1].split("</loc>")[0]
-            if "/engineering/" in url and url != "https://www.anthropic.com/engineering":
-                result["engineering"].append(url)
-            elif "/product/" in url:
-                result["product"].append(url)
-            elif "/news/" in url and url != "https://www.anthropic.com/news":
-                slug = url.rsplit("/", 1)[-1].lower()
-                if any(kw in slug for kw in NEWS_KEYWORDS):
-                    result["news"].append(url)
-            elif "/research/" in url and url != "https://www.anthropic.com/research":
-                if "/research/team/" not in url:
-                    result["research"].append(url)
-        return result
-
     def extract_support_urls(self, sitemap_xml: str) -> List[str]:
+        # Articles serve a .md variant directly (since ~2026-07), so plain
+        # download_doc applies; sitemap covers more articles than llms.txt.
         return [
             url for url in self.extract_sitemap_urls(sitemap_xml)
             if "/en/articles/" in url
@@ -196,55 +164,6 @@ class Fetcher:
                 return {"url": url, "status": "skipped"}
             try:
                 content = await self.fetch_bytes(session, f"{url}.md")
-                output_path.parent.mkdir(parents=True, exist_ok=True)
-                async with aiofiles.open(output_path, "wb") as f:
-                    await f.write(content)
-                self.stats["downloaded"] += 1
-                return {
-                    "url": url, "status": "success",
-                    "path": str(output_path.relative_to(self.output_dir)),
-                    "sha256": hashlib.sha256(content).hexdigest(),
-                    "size": len(content),
-                }
-            except Exception as e:
-                self.stats["failed"] += 1
-                return {"url": url, "status": "failed", "error": str(e)}
-
-    async def download_via_jina(self, session, url, output_subdir, semaphore) -> Dict:
-        async with semaphore:
-            slug = url.split("anthropic.com/")[1] if "anthropic.com" in url else url.rsplit("/", 1)[-1]
-            output_path = self.output_dir / "blog" / f"{slug}.md"
-            if output_subdir:
-                output_path = self.output_dir / output_subdir / f"{slug}.md"
-            if self.incremental and output_path.exists():
-                self.stats["skipped"] += 1
-                return {"url": url, "status": "skipped"}
-            try:
-                content = await self.fetch_bytes(
-                    session, f"https://r.jina.ai/{url}", headers=self._jina_headers())
-                output_path.parent.mkdir(parents=True, exist_ok=True)
-                async with aiofiles.open(output_path, "wb") as f:
-                    await f.write(content)
-                self.stats["downloaded"] += 1
-                return {
-                    "url": url, "status": "success",
-                    "path": str(output_path.relative_to(self.output_dir)),
-                    "sha256": hashlib.sha256(content).hexdigest(),
-                    "size": len(content),
-                }
-            except Exception as e:
-                self.stats["failed"] += 1
-                return {"url": url, "status": "failed", "error": str(e)}
-
-    async def download_support_article(self, session, url, semaphore) -> Dict:
-        async with semaphore:
-            output_path = self.get_output_path(url)
-            if self.incremental and output_path.exists():
-                self.stats["skipped"] += 1
-                return {"url": url, "status": "skipped"}
-            try:
-                content = await self.fetch_bytes(
-                    session, f"https://r.jina.ai/{url}", headers=self._jina_headers())
                 output_path.parent.mkdir(parents=True, exist_ok=True)
                 async with aiofiles.open(output_path, "wb") as f:
                     await f.write(content)
@@ -345,7 +264,6 @@ class Fetcher:
 
             tasks = []
             semaphore = asyncio.Semaphore(self.jobs)
-            jina_semaphore = asyncio.Semaphore(min(self.jobs, 10))
             counts = {}
 
             # -- Platform docs --
@@ -382,20 +300,9 @@ class Fetcher:
                 for url in urls:
                     tasks.append(self.download_doc(session, url, semaphore))
 
-            # -- Blog: engineering, research, news, product --
-            if self.want("blog", "engineering", "research", "news"):
-                print("Source: anthropic.com/sitemap.xml")
-                xml = await self.fetch_text(session, self.anthropic_sitemap_url)
-                blog = self.filter_blog_urls(xml)
-
-                for category, urls in blog.items():
-                    if not self.want("blog", category):
-                        continue
-                    counts[f"blog/{category}"] = len(urls)
-                    print(f"  {len(urls)} {category}")
-                    for url in urls:
-                        tasks.append(self.download_via_jina(
-                            session, url, None, jina_semaphore))
+            # -- Blog (anthropic.com): FROZEN 2026-07 --
+            # HTML-only upstream (no llms.txt / .md variant); the jina.ai
+            # proxy path was removed. content/blog/ stays as a static archive.
 
             # -- Support articles --
             if self.want("support"):
@@ -405,8 +312,7 @@ class Fetcher:
                 counts["support"] = len(urls)
                 print(f"  {len(urls)} articles")
                 for url in urls:
-                    tasks.append(self.download_support_article(
-                        session, url, jina_semaphore))
+                    tasks.append(self.download_doc(session, url, semaphore))
 
             # -- GitHub repos --
             if self.want("github"):
@@ -558,10 +464,8 @@ class Fetcher:
             cc_urls = await self.fetch_claude_code_urls(session)
             mcp_urls = self.extract_sitemap_urls(
                 await self.fetch_text(session, self.mcp_sitemap_url))
-            anthropic_xml = await self.fetch_text(session, self.anthropic_sitemap_url)
-            blog = self.filter_blog_urls(anthropic_xml)
-            support_xml = await self.fetch_text(session, self.support_sitemap_url)
-            support_urls = self.extract_support_urls(support_xml)
+            support_urls = self.extract_support_urls(
+                await self.fetch_text(session, self.support_sitemap_url))
 
         def show_grouped(title, urls, strip_prefix):
             print(f"{title} ({len(urls)})")
@@ -579,16 +483,12 @@ class Fetcher:
         show_grouped("platform.claude.com", platform_urls, "https://platform.claude.com/docs/en/")
         show_grouped("modelcontextprotocol.io", mcp_urls, "https://modelcontextprotocol.io/")
 
-        print(f"anthropic.com blog")
-        print("-" * 50)
-        for cat, urls in blog.items():
-            print(f"  {cat}: {len(urls)}")
-        print()
         print(f"support.claude.com: {len(support_urls)} articles")
+        print("anthropic.com blog: frozen archive (not fetched)")
         print(f"GitHub repos: {len(GITHUB_REPOS)} repos configured")
         print()
 
-        total = len(cc_urls) + len(platform_urls) + len(mcp_urls) + sum(len(v) for v in blog.values()) + len(support_urls)
+        total = len(cc_urls) + len(platform_urls) + len(mcp_urls) + len(support_urls)
         print(f"Total fetchable: {total}+ (excludes GitHub repos)")
 
     # -- Discovery ---------------------------------------------------------
@@ -702,19 +602,18 @@ Sections:
   claude-code   Claude Code + Agent SDK docs (code.claude.com)
   api/platform  API and platform docs (platform.claude.com)
   mcp           MCP protocol spec (modelcontextprotocol.io)
-  blog          All blog content (engineering + research + news + product)
-  engineering   Engineering blog only
-  research      Research posts only
-  news          Filtered news (model releases, Claude updates)
   github        All configured GitHub repos
-  support       Support articles (support.claude.com)
+  support       Support articles (support.claude.com, sitemap + .md)
   all           Everything (default)
+
+Note: content/blog/ (anthropic.com engineering/research/news) is a
+frozen archive as of 2026-07 — the site is HTML-only and the jina.ai
+proxy path was removed.
 
 Examples:
   fetcher.py                               Fetch everything
   fetcher.py --section mcp                 MCP spec only
   fetcher.py --section github              GitHub repos only
-  fetcher.py --section engineering          Engineering blog only
   fetcher.py --tree                         Show all sources
   fetcher.py --discover                     Probe domains for new sources
   fetcher.py --incremental                  Skip existing files
@@ -728,7 +627,6 @@ Examples:
         "--section", "-s",
         choices=[
             "claude-code", "api", "platform", "mcp",
-            "blog", "engineering", "research", "news",
             "github", "support", "all",
         ],
     )

--- a/scripts/fetcher.py
+++ b/scripts/fetcher.py
@@ -107,10 +107,19 @@ class Fetcher:
             r.raise_for_status()
             return await r.text()
 
-    async def fetch_bytes(self, session: aiohttp.ClientSession, url: str) -> bytes:
-        async with session.get(url) as r:
+    async def fetch_bytes(
+        self, session: aiohttp.ClientSession, url: str,
+        headers: Optional[Dict] = None,
+    ) -> bytes:
+        async with session.get(url, headers=headers) as r:
             r.raise_for_status()
             return await r.read()
+
+    def _jina_headers(self) -> Optional[Dict]:
+        # Without a key, r.jina.ai rate-limits hard (~95% failures at 10
+        # concurrent). Set JINA_API_KEY to lift blog/support success rates.
+        key = os.environ.get("JINA_API_KEY")
+        return {"Authorization": f"Bearer {key}"} if key else None
 
     def extract_sitemap_urls(self, xml: str, must_contain: str = "") -> List[str]:
         urls = []
@@ -211,7 +220,8 @@ class Fetcher:
                 self.stats["skipped"] += 1
                 return {"url": url, "status": "skipped"}
             try:
-                content = await self.fetch_bytes(session, f"https://r.jina.ai/{url}")
+                content = await self.fetch_bytes(
+                    session, f"https://r.jina.ai/{url}", headers=self._jina_headers())
                 output_path.parent.mkdir(parents=True, exist_ok=True)
                 async with aiofiles.open(output_path, "wb") as f:
                     await f.write(content)
@@ -233,7 +243,8 @@ class Fetcher:
                 self.stats["skipped"] += 1
                 return {"url": url, "status": "skipped"}
             try:
-                content = await self.fetch_bytes(session, f"https://r.jina.ai/{url}")
+                content = await self.fetch_bytes(
+                    session, f"https://r.jina.ai/{url}", headers=self._jina_headers())
                 output_path.parent.mkdir(parents=True, exist_ok=True)
                 async with aiofiles.open(output_path, "wb") as f:
                     await f.write(content)
@@ -342,8 +353,13 @@ class Fetcher:
                 print("Source: platform.claude.com/sitemap.xml")
                 xml = await self.fetch_text(session, self.platform_sitemap_url)
                 urls = self.extract_sitemap_urls(xml, "/docs/en/")
+                # Terraform provider reference serves no .md variant (404s)
+                terraform = [u for u in urls if "/api/terraform/" in u]
+                urls = [u for u in urls if "/api/terraform/" not in u]
                 counts["platform"] = len(urls)
-                print(f"  {len(urls)} docs")
+                print(f"  {len(urls)} docs"
+                      + (f" ({len(terraform)} terraform pages skipped, no .md)"
+                         if terraform else ""))
                 for url in urls:
                     tasks.append(self.download_doc(session, url, semaphore))
 
@@ -413,8 +429,23 @@ class Fetcher:
             if tasks:
                 results = await tqdm_asyncio.gather(*tasks, desc="Fetching", unit="file")
                 await self._save_metadata(results)
+                self._print_failures(results)
 
         self._print_summary()
+
+    def _print_failures(self, results: List[Dict]):
+        failed = [r for r in results if r.get("status") == "failed"]
+        if not failed:
+            return
+        by_host = defaultdict(int)
+        for r in failed:
+            by_host[r["url"].split("/")[2]] += 1
+        print("\nFailed by host:")
+        for host, n in sorted(by_host.items(), key=lambda kv: -kv[1]):
+            print(f"  {host}: {n}")
+        print("Sample errors:")
+        for r in failed[:3]:
+            print(f"  {r['url']}: {str(r.get('error', ''))[:120]}")
 
     async def _fetch_meta(self, session):
         print("Meta: NPM manifest + CHANGELOG")
@@ -446,6 +477,10 @@ class Fetcher:
                 "section": self.section or "all",
             },
             "items": [r for r in results if r.get("status") == "success"],
+            "failures": [
+                {"url": r["url"], "error": str(r.get("error", ""))[:200]}
+                for r in results if r.get("status") == "failed"
+            ],
             "summary": {
                 "total": self.stats["total"],
                 "downloaded": self.stats["downloaded"],

--- a/sources.json
+++ b/sources.json
@@ -1,25 +1,58 @@
 {
   "version": "2.0",
-  "updated": "2026-05-28",
+  "updated": "2026-07-08",
   "description": "Complete Anthropic content source registry. Discovered via robots.txt/sitemap/llms.txt probing across all known Anthropic domains, GitHub API enumeration, and package registry checks.",
-
   "domains": {
-    "anthropic.com":           {"robots": true,  "sitemap": true,  "llms_txt": false, "notes": "Main site: news, engineering, research"},
-    "platform.claude.com":     {"robots": true,  "sitemap": true,  "llms_txt": true,  "llms_full": true, "notes": "API/platform docs (1541 en pages)"},
-    "code.claude.com":         {"robots": true,  "sitemap": true,  "llms_txt": true,  "notes": "Claude Code + Agent SDK docs (141 en pages, 9 languages)"},
-    "support.claude.com":      {"robots": true,  "sitemap": true,  "llms_txt": false, "notes": "Help articles (343 en, Intercom-hosted)"},
-    "modelcontextprotocol.io": {"robots": true,  "sitemap": true,  "llms_txt": true,  "notes": "MCP spec + community (203 pages)"},
-    "claude.ai":               {"robots": true,  "sitemap": "cf-blocked", "llms_txt": false, "notes": "Product app, Cloudflare-protected"},
-    "claude.com":              {"robots": true,  "sitemap": "cf-blocked", "llms_txt": false, "notes": "Product landing, redirects to claude.ai"}
+    "anthropic.com": {
+      "robots": true,
+      "sitemap": true,
+      "llms_txt": false,
+      "notes": "Main site: news, engineering, research"
+    },
+    "platform.claude.com": {
+      "robots": true,
+      "sitemap": true,
+      "llms_txt": true,
+      "llms_full": true,
+      "notes": "API/platform docs (1541 en pages)"
+    },
+    "code.claude.com": {
+      "robots": true,
+      "sitemap": true,
+      "llms_txt": true,
+      "notes": "Claude Code + Agent SDK docs (141 en pages, 9 languages)"
+    },
+    "support.claude.com": {
+      "robots": true,
+      "sitemap": true,
+      "llms_txt": true,
+      "notes": "Help articles (Intercom-hosted); llms.txt with direct .md links since ~2026-07"
+    },
+    "modelcontextprotocol.io": {
+      "robots": true,
+      "sitemap": true,
+      "llms_txt": true,
+      "notes": "MCP spec + community (203 pages)"
+    },
+    "claude.ai": {
+      "robots": true,
+      "sitemap": "cf-blocked",
+      "llms_txt": false,
+      "notes": "Product app, Cloudflare-protected"
+    },
+    "claude.com": {
+      "robots": true,
+      "sitemap": "cf-blocked",
+      "llms_txt": false,
+      "notes": "Product landing, redirects to claude.ai"
+    }
   },
-
   "aliases": {
     "console.anthropic.com": "platform.claude.com",
-    "docs.anthropic.com":    "platform.claude.com",
+    "docs.anthropic.com": "platform.claude.com",
     "support.anthropic.com": "support.claude.com",
-    "www.claude.com":        "claude.com"
+    "www.claude.com": "claude.com"
   },
-
   "sources": [
     {
       "name": "platform-docs",
@@ -29,7 +62,10 @@
       "output": "en/",
       "pages": 1541,
       "enabled": true,
-      "section": ["api", "platform"]
+      "section": [
+        "api",
+        "platform"
+      ]
     },
     {
       "name": "claude-code-docs",
@@ -39,7 +75,9 @@
       "output": "en/docs/claude-code/",
       "pages": 141,
       "enabled": true,
-      "section": ["claude-code"],
+      "section": [
+        "claude-code"
+      ],
       "notes": "Sitemap has lastmod timestamps; llms.txt does not"
     },
     {
@@ -50,54 +88,94 @@
       "output": "mcp/",
       "pages": 203,
       "enabled": true,
-      "section": ["mcp"],
+      "section": [
+        "mcp"
+      ],
       "notes": "MCP spec, tutorials, SDK docs, governance, community charters"
     },
     {
       "name": "support-articles",
-      "type": "sitemap-jina",
-      "sitemap": "https://support.claude.com/sitemap.xml",
+      "type": "sitemap-md",
       "filter": "/en/articles/",
       "output": "support/",
       "pages": 343,
       "enabled": true,
-      "section": ["support"],
-      "notes": "Intercom-hosted, needs jina.ai proxy. Multi-language."
+      "section": [
+        "support"
+      ],
+      "notes": "Intercom-hosted; every article serves a .md variant directly (since ~2026-07), fetched sitemap + .md suffix. Previously jina.ai proxy. English-only filter.",
+      "sitemap": "https://support.claude.com/sitemap.xml"
     },
     {
       "name": "engineering-blog",
       "type": "sitemap-jina",
       "sitemap": "https://www.anthropic.com/sitemap.xml",
       "filter": "/engineering/",
-      "exclude_exact": ["https://www.anthropic.com/engineering"],
+      "exclude_exact": [
+        "https://www.anthropic.com/engineering"
+      ],
       "output": "blog/engineering/",
       "pages": 26,
-      "enabled": true,
-      "section": ["blog", "engineering"]
+      "enabled": false,
+      "section": [
+        "blog",
+        "engineering"
+      ],
+      "notes": "FROZEN 2026-07-08: anthropic.com is HTML-only (no llms.txt/.md); jina.ai proxy dependency removed. content/blog/ kept as static archive."
     },
     {
       "name": "research-posts",
       "type": "sitemap-jina",
       "sitemap": "https://www.anthropic.com/sitemap.xml",
       "filter": "/research/",
-      "exclude_exact": ["https://www.anthropic.com/research"],
-      "exclude_pattern": ["/research/team/"],
+      "exclude_exact": [
+        "https://www.anthropic.com/research"
+      ],
+      "exclude_pattern": [
+        "/research/team/"
+      ],
       "output": "blog/research/",
       "pages": 122,
-      "enabled": true,
-      "section": ["blog", "research"]
+      "enabled": false,
+      "section": [
+        "blog",
+        "research"
+      ],
+      "notes": "FROZEN 2026-07-08: anthropic.com is HTML-only (no llms.txt/.md); jina.ai proxy dependency removed. content/blog/ kept as static archive."
     },
     {
       "name": "news-posts",
       "type": "sitemap-jina-filtered",
       "sitemap": "https://www.anthropic.com/sitemap.xml",
       "filter": "/news/",
-      "exclude_exact": ["https://www.anthropic.com/news"],
-      "keywords": ["claude", "model", "api", "agent", "mcp", "sdk", "opus", "sonnet", "haiku", "code", "bedrock", "vertex", "foundry", "tool", "safety"],
+      "exclude_exact": [
+        "https://www.anthropic.com/news"
+      ],
+      "keywords": [
+        "claude",
+        "model",
+        "api",
+        "agent",
+        "mcp",
+        "sdk",
+        "opus",
+        "sonnet",
+        "haiku",
+        "code",
+        "bedrock",
+        "vertex",
+        "foundry",
+        "tool",
+        "safety"
+      ],
       "output": "blog/news/",
       "pages": "~100 (filtered from 217)",
-      "enabled": true,
-      "section": ["blog", "news"]
+      "enabled": false,
+      "section": [
+        "blog",
+        "news"
+      ],
+      "notes": "FROZEN 2026-07-08: anthropic.com is HTML-only (no llms.txt/.md); jina.ai proxy dependency removed. content/blog/ kept as static archive."
     },
     {
       "name": "product-pages",
@@ -106,118 +184,165 @@
       "filter": "/product/",
       "output": "blog/product/",
       "pages": 4,
-      "enabled": true,
-      "section": ["blog"]
+      "enabled": false,
+      "section": [
+        "blog"
+      ],
+      "notes": "FROZEN 2026-07-08: anthropic.com is HTML-only (no llms.txt/.md); jina.ai proxy dependency removed. content/blog/ kept as static archive."
     },
     {
       "name": "github-cookbooks",
       "type": "github-repo",
       "repo": "anthropics/claude-cookbooks",
       "branch": "main",
-      "extensions": [".md", ".ipynb"],
+      "extensions": [
+        ".md",
+        ".ipynb"
+      ],
       "output": "github/cookbooks/",
       "pages": 164,
       "enabled": true,
-      "section": ["github"]
+      "section": [
+        "github"
+      ]
     },
     {
       "name": "github-skills",
       "type": "github-repo",
       "repo": "anthropics/skills",
       "branch": "main",
-      "extensions": [".md"],
+      "extensions": [
+        ".md"
+      ],
       "output": "github/skills/",
       "pages": 90,
       "enabled": true,
-      "section": ["github"]
+      "section": [
+        "github"
+      ]
     },
     {
       "name": "github-plugins-official",
       "type": "github-repo",
       "repo": "anthropics/claude-plugins-official",
       "branch": "main",
-      "extensions": [".md", ".json"],
+      "extensions": [
+        ".md",
+        ".json"
+      ],
       "output": "github/plugins-official/",
       "pages": 266,
       "enabled": true,
-      "section": ["github"]
+      "section": [
+        "github"
+      ]
     },
     {
       "name": "github-courses",
       "type": "github-repo",
       "repo": "anthropics/courses",
       "branch": "master",
-      "extensions": [".md", ".ipynb"],
+      "extensions": [
+        ".md",
+        ".ipynb"
+      ],
       "output": "github/courses/",
       "pages": 80,
       "enabled": true,
-      "section": ["github"]
+      "section": [
+        "github"
+      ]
     },
     {
       "name": "github-quickstarts",
       "type": "github-repo",
       "repo": "anthropics/claude-quickstarts",
       "branch": "main",
-      "extensions": [".md"],
+      "extensions": [
+        ".md"
+      ],
       "output": "github/quickstarts/",
       "pages": 17,
       "enabled": true,
-      "section": ["github"]
+      "section": [
+        "github"
+      ]
     },
     {
       "name": "github-code-action",
       "type": "github-repo",
       "repo": "anthropics/claude-code-action",
       "branch": "main",
-      "extensions": [".md"],
+      "extensions": [
+        ".md"
+      ],
       "output": "github/code-action/",
       "pages": 32,
       "enabled": true,
-      "section": ["github"]
+      "section": [
+        "github"
+      ]
     },
     {
       "name": "github-workshops",
       "type": "github-repo",
       "repo": "anthropics/cwc-workshops",
       "branch": "main",
-      "extensions": [".md", ".ipynb"],
+      "extensions": [
+        ".md",
+        ".ipynb"
+      ],
       "output": "github/workshops/",
       "pages": 36,
       "enabled": true,
-      "section": ["github"]
+      "section": [
+        "github"
+      ]
     },
     {
       "name": "github-long-running-agents",
       "type": "github-repo",
       "repo": "anthropics/cwc-long-running-agents",
       "branch": "main",
-      "extensions": [".md"],
+      "extensions": [
+        ".md"
+      ],
       "output": "github/long-running-agents/",
       "pages": 4,
       "enabled": true,
-      "section": ["github"]
+      "section": [
+        "github"
+      ]
     },
     {
       "name": "github-sdk-python",
       "type": "github-repo",
       "repo": "anthropics/anthropic-sdk-python",
       "branch": "main",
-      "extensions": [".md"],
+      "extensions": [
+        ".md"
+      ],
       "output": "github/sdk-python/",
       "pages": 10,
       "enabled": true,
-      "section": ["github"]
+      "section": [
+        "github"
+      ]
     },
     {
       "name": "github-sdk-typescript",
       "type": "github-repo",
       "repo": "anthropics/anthropic-sdk-typescript",
       "branch": "main",
-      "extensions": [".md"],
+      "extensions": [
+        ".md"
+      ],
       "output": "github/sdk-typescript/",
       "pages": 20,
       "enabled": true,
-      "section": ["github"]
+      "section": [
+        "github"
+      ]
     },
     {
       "name": "npm-claude-code",
@@ -225,7 +350,9 @@
       "package": "@anthropic-ai/claude-code",
       "output": "claude-code-manifest.json",
       "enabled": true,
-      "section": ["meta"]
+      "section": [
+        "meta"
+      ]
     },
     {
       "name": "github-changelog",
@@ -233,7 +360,9 @@
       "url": "https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md",
       "output": "CHANGELOG.md",
       "enabled": true,
-      "section": ["meta"]
+      "section": [
+        "meta"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## The incident

Every scheduled run since ~June 14: fetch works → Claude commits and pushes a branch → `gh pr create` **silently denied** → Bark notification sent anyway → run exits green. 31 orphan `docs/claude-code-v2.1.*` branches, zero PRs, main stale for 3 weeks, and daily false-positive notifications.

Root cause: the workflow tracked `anthropics/claude-code-action@main`, whose `claude_args` parsing changed to split `--allowedTools Bash(gh pr:*),…` on whitespace — producing `Bash(gh` + `pr:*)`, two invalid rules. `Bash(git:*)` survived (no space), which is why branches kept getting pushed while PR creation died.

## The fix (defense in depth)

| layer | change |
|---|---|
| permissions | moved to `.claude/settings.json` — JSON is immune to arg-parsing changes; CI already loads project settings |
| supply chain | action pinned to `v1.0.168` instead of moving `@main` |
| tripwire | new `Verify outcome` step: pushed branch without PR, or dirty workspace after agent step → **red run** |
| notifications | bark only after a real PR URL exists; failure alert otherwise |
| fetcher | failures recorded in `.metadata.json` + per-host breakdown printed (731/run were silently discarded) |

## Jina.ai deprecated (second commit)

The 731 failures broke down as: 574 = r.jina.ai rate limiting (blog + support proxied fetches), 157 = platform terraform pages with no `.md` variant. Resolution — remove the jina dependency entirely:

- **support.claude.com**: every article now serves a `.md` variant directly (verified 2026-07-08) → fetched like platform/code/mcp docs. **355/355 articles** vs 4/355 through rate-limited jina.
- **anthropic.com blog**: still HTML-only (no llms.txt / `.md` / content negotiation) → **frozen**. `content/blog/` stays as a static archive; sources disabled in `sources.json` with dated notes; `--section` choices trimmed.
- **platform terraform pages**: skipped with a printed note (404 on `.md` upstream).
- No `JINA_API_KEY` secret needed — that plumbing is removed.

## Verified

- Full run: **3,231/3,231 downloaded, 0 failed** (was 2,907/3,638, 731 failed, 79.7%)
- `--section support` isolated run: 355/355
- YAML + Python syntax checked; `.claude/settings.json` load path confirmed against the action's `settingSources: [user, project, local]`

## Follow-ups (not in this PR)

- Delete the 31 orphan branches after #1046 merges (auto-delete-on-merge is now enabled repo-side)
- `content/github/**` mirrors ship `.claude/` dirs the root ignore used to swallow — decide whether to archive them
- If blog coverage matters again later: needs an HTML→md pipeline or an upstream llms.txt appearing on anthropic.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)