### PR TITLE
ci: temporarily enable show_full_output to diagnose agent permission denials

### DIFF
--- a/.github/workflows/fetch-claude-docs.yml
+++ b/.github/workflows/fetch-claude-docs.yml
@@ -66,6 +66,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
           allowed_bots: "claude-yolo[bot]"
+          # TEMPORARY: expose agent transcript to diagnose permission denials
+          show_full_output: true
           claude_args: |
             --model claude-sonnet-4-6
             --mcp-config '{


### PR DESCRIPTION
Diagnostic: agent step reports permission_denials_count 4-9 and leaves workspace dirty. Transcript is hidden by default; this exposes it for one run to enumerate the denied tool calls. Will be reverted in the real fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)