### PR TITLE
fix: restore full-auto PR pipeline end to end

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,10 +2,20 @@
   "permissions": {
     "allow": [
       "Bash(gh pr:*)",
+      "Bash(gh issue:*)",
+      "Bash(gh release:*)",
       "Bash(git:*)",
       "Bash(npm:*)",
       "Bash(jq:*)",
       "Bash(date:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(grep:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(wc:*)",
+      "Bash(echo:*)",
+      "Bash(uv run scripts/fetcher.py:*)",
       "Bash(./scripts/create-docs-pr.sh:*)",
       "mcp__barkme__notify"
     ]

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -67,7 +67,11 @@ jobs:
         if: |
           !contains(github.event.pull_request.title, '[skip-review]') &&
           !contains(github.event.pull_request.title, '[WIP]')
-        uses: anthropics/claude-code-action@main
+        # Pinned like fetch-claude-docs.yml: @main's claude_args parsing split
+        # '--allowedTools Bash(gh pr:*)' on whitespace, silently denying
+        # 'gh pr merge' - auto-merge was dead. Tool permissions live in
+        # .claude/settings.json (settingSources=project), not in claude_args.
+        uses: anthropics/claude-code-action@v1.0.168
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
@@ -76,7 +80,6 @@ jobs:
           allowed_bots: "claude-yolo[bot],github-actions[bot]"
           claude_args: |
             --model claude-sonnet-4-6
-            --allowedTools Bash(gh pr:*),Bash(git:*),Bash(gh issue:*),Bash(gh release:*),Bash(npm:*),Bash(ls:*),Bash(cat:*),Bash(grep:*),Bash(uv run scripts/fetcher.py:*),Bash(jq:*),mcp__barkme__notify
             --mcp-config '{
               "mcpServers": {
                 "barkme": {

--- a/.github/workflows/fetch-claude-docs.yml
+++ b/.github/workflows/fetch-claude-docs.yml
@@ -66,8 +66,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
           allowed_bots: "claude-yolo[bot]"
-          # TEMPORARY: expose agent transcript to diagnose permission denials
-          show_full_output: true
           claude_args: |
             --model claude-sonnet-4-6
             --mcp-config '{
@@ -122,14 +120,12 @@ jobs:
 
             ## DECISION CRITERIA (based on WHY it matters)
 
-            IGNORE (noise; do not commit/PR):
-            - Only blog/research content changed with no other files
-            - Only github/ repo content changed with no other files
-            - Only .metadata.json changed
+            This repo is an archive: EVERY fetched change gets committed.
+            main is push-protected (branch ruleset, no bypass), so all
+            changes travel through a PR - even minor ones. What varies is
+            whether humans hear about it:
 
-            If the diff contains only low-signal changes: do nothing, exit 0.
-
-            **CREATE PR** (WHY: humans need to know):
+            **PR + leave open for day shift** (WHY: humans need to know):
             - Version updates in content/claude-code-manifest.json
             - New features documented in claude-code or agent-sdk docs
             - CHANGELOG additions
@@ -137,30 +133,34 @@ jobs:
             - Breaking changes
             - Security-related updates
             - New MCP spec versions
-            - New engineering blog posts (high signal)
 
-            **COMMIT DIRECTLY** (WHY: not worth human attention):
-            - Typo fixes < 5 lines
-            - Timestamp updates
-            - Metadata changes
-            - Formatting tweaks
-            - Dead link fixes
-            - Minor doc wording changes
+            **PR + self-merge immediately** (WHY: archive freshness, zero human value):
+            - Only github/ mirror or support/ content changed
+            - Only .metadata.json / timestamps changed
+            - Typo fixes, formatting tweaks, dead links, minor wording
+
+            If `git status` is completely clean: nothing to do, exit 0.
 
             ## HOW TO HANDLE
 
-            **For meaningful changes (PR needed)**:
-            ```bash
-            PR_URL=$(./scripts/create-docs-pr.sh "{key feature}" "{why it matters}" "{version}")
-            # Barkme notification with PR URL
-            ```
+            IMPORTANT - invoke the PR script as ONE single line: no
+            backslash line-continuations, no $( ) command-substitution
+            wrapper. The permission allowlist matches command prefixes,
+            and a multi-line command is silently DENIED (this exact
+            failure stalled the pipeline in July 2026).
 
-            **For minor changes (direct commit)**:
+            **For meaningful changes (PR for day shift)**:
             ```bash
-            git add .
-            git commit -m "docs: {what} (minor)"
-            git push
+            ./scripts/create-docs-pr.sh "{key feature}" "{why it matters}" "{version}"
             ```
+            The script prints the PR URL on its last line. Then barkme.
+
+            **For minor changes (PR + immediate self-merge)**:
+            ```bash
+            ./scripts/create-docs-pr.sh "{what} (minor)" "{one-line why}" "{version}"
+            gh pr merge {pr-url} --rebase
+            ```
+            No barkme for minor self-merges.
 
             ## OUTPUT STYLE
             - Focus on WHY changes matter, not WHAT changed
@@ -211,7 +211,9 @@ jobs:
             exit 1
           fi
           if [ "$BRANCH" != "main" ] && [ -n "$BRANCH" ]; then
-            PRS=$(gh pr list --head "$BRANCH" --json number --jq 'length')
+            # --state all: minor PRs are self-merged (and their branch
+            # auto-deleted) before this step runs - that is success, not failure
+            PRS=$(gh pr list --head "$BRANCH" --state all --json number --jq 'length')
             if [ "$PRS" = "0" ]; then
               echo "::error::Branch $BRANCH pushed but no PR exists - PR creation silently failed"
               exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -16,10 +16,12 @@ dist/
 .claude-trace/
 
 # Local development (root only; keep settings.json tracked: CI reads tool
-# permissions from it via settingSources=project. Note: content/github/**
-# mirrors still ship .claude/ dirs we currently do not archive.)
+# permissions from it via settingSources=project.)
 /.claude/*
 !/.claude/settings.json
+# github mirrors ship .claude/ dirs we do not archive; left untracked they
+# dirty the CI workspace every run and trip the Verify outcome step
+content/github/**/.claude/
 worktree/
 WIP/
 references/


### PR DESCRIPTION
Follow-up to #1047, driven by live verification runs (29438312884, 29439327563 with full output).

## What was still broken after #1047

| break | evidence | fix |
|---|---|---|
| Agent's `create-docs-pr.sh` call denied | transcript: 4 denials, all the multi-line invocation (backslash continuations) — prefix rules don't match multi-line commands | prompt mandates single-line invocation; explains the denial mechanics |
| 'Commit directly to main' path impossible | main ruleset: PRs required, zero bypass actors — even the app token can't push | minor changes = PR + immediate self-merge (`gh pr merge --rebase`, 0 approvals needed) |
| Day-shift auto-merge dead | `claude-review.yml` still on `@main` with `--allowedTools Bash(gh pr:*)` in claude_args — same whitespace-split bug as the June incident | pinned to v1.0.168, allowlist moved to shared `.claude/settings.json` |
| Workspace always dirty in CI | #1047's root-only `/.claude/*` ignore unignored `content/github/**/.claude/` mirror dirs → tripwire red every run | re-ignored |
| Tripwire false positive on self-merge | `gh pr list --head` defaults to open PRs; a self-merged PR (branch auto-deleted) reads as 'no PR' | `--state all` |

Also removes the temporary `show_full_output` diagnostic flag (#1048).

## Verification plan
Manual `workflow_dispatch` after merge: expect green run + a real PR for the pending v2.1.205-210 catch-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)