### PR TITLE
fix: Write tool needs its own permission rule on Claude Code 2.1.204

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,8 @@
       "Bash(uv run scripts/fetcher.py:*)",
       "Bash(./scripts/create-docs-pr.sh:*)",
       "Edit(.decision/**)",
+      "Write(.decision/**)",
+      "Bash(mkdir:*)",
       "mcp__barkme__notify"
     ]
   }


### PR DESCRIPTION
Run 29441419112 transcript: the decider agent wrote correct .decision files but all Write calls were denied. Edit(path) rules only cover Write from Claude Code 2.1.210; the pinned action runs 2.1.204. Added Write(.decision/**) + Bash(mkdir:*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)