### PR TITLE
fix(review): stop filing tracking issues into deva [skip-review]

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -118,14 +118,25 @@ jobs:
             ## YOUR PHILOSOPHY
             "Why make effort when less effort works?"
             - Auto-merge what's obviously fine (WHY: saves everyone time)
-            - Create issues for version updates (WHY: humans want to know about new features)
             - Ping humans only for breaking changes (WHY: they'll be mad if stuff breaks)
+
+            ## HARD RULE: NEVER CREATE ISSUES
+            You do not open issues. Not here, not in any other repo, ever.
+            The merged PR is the version record and night shift already sent
+            the Bark push - an issue is a third copy of the same facts.
+            (July 2026: this instruction used to say "file a tracking issue in
+            thevibeworks/claude-code-yolo". That repo was renamed to deva, so
+            377 issues landed in an unrelated project, half of them duplicated
+            because the `gh issue list --search` dedup gate reads GitHub's
+            search index, which lags writes by minutes. Do not reinvent this.)
+            Your token is a GitHub App token installed org-wide. Writes outside
+            this repo are possible and are always a bug.
 
             ## DECISION LOGIC (based on WHY it matters)
 
             **Quick review & merge** (WHY: night shift already analyzed):
             - Your own fetch-docs PRs from night shift
-            - Check the highlights, create version tracking issue if needed
+            - Check the highlights, sanity-check the PR title
             - Merge unless something looks wrong
             - Night shift already barked, so no need to bark again
             
@@ -149,14 +160,9 @@ jobs:
             ## SPECIAL CASE: Night Shift PRs
             When reviewing PRs from your night shift (fetch-docs workflow):
             1. Quick review - night shift already did the analysis
-            2. If version changed: create tracking issue in thevibeworks/claude-code-yolo
-               - FIRST check for duplicates: `gh issue list --repo thevibeworks/claude-code-yolo --search "Claude Code v{version}" --state all --limit 5`
-               - Only create if NO existing issue for this version exists (title starts with "Claude Code v{version}")
-               - Title: "Claude Code v{old} → v{new}: {most interesting feature}"
-               - Body: WHY users should care + link to this PR
-               - Assign to @lroolle
-            3. Merge the PR (unless something is obviously wrong)
-            4. DON'T barkme again - night shift already did
+            2. Merge the PR (unless something is obviously wrong)
+            3. DON'T barkme again - night shift already did
+            4. DON'T open a tracking issue - see the hard rule above
 
             ## YOUR TASKS (in order of laziness)
             1. Skim the diff (WHY: need to know if it's worth attention)


### PR DESCRIPTION
## What

Removes the version-tracking-issue step from the day-shift review prompt.

## Why

`claude-review.yml` told the agent to file a tracking issue in
`thevibeworks/claude-code-yolo`. That repo was renamed to **deva**, so GitHub
redirected every issue into an unrelated project — **377 issues**, all with zero
comments, zero reactions, zero assignees, each one also firing a junk workflow
run in deva.

About half were exact duplicates. The dedup gate was
`gh issue list --search`, which reads GitHub's *search index* — that lags writes
by minutes, so the agent could not see what it had just created and filed the
same body twice within a single run:

> run `30512240113` → `deva#531` (03:51:50Z) and `deva#532` (03:52:03Z),
> byte-identical bodies, 8 turns, 0 permission denials.

Fixing only the repo name would have kept the race. Dropping the step removes
it — the merged PR is already the version record and night shift already sends
the Bark push, so the issue was a third copy of facts published twice.

Same lesson `fetch-claude-docs.yml` learned in June: an LLM cannot be the
idempotency gate for a side effect.

## Note on `[skip-review]`

Deliberate. For `pull_request` events GitHub runs the workflow definition from
the **base** branch, so letting the day shift review this PR would run the buggy
prompt one last time and file one more orphan issue.

## Follow-up

The 377 issues in deva are being deleted separately.