### PR TITLE
docs: the Content table documented three sections that do not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # Claude Code Docs
 
-> Comprehensive, auto-updating archive of everything Anthropic publishes
-> for building with Claude. 3,900+ docs from 12 sources.
+> Auto-updating archive of Anthropic's builder documentation: every source
+> that publishes markdown, fetched 4x daily. 4,100 files from six live sources,
+> plus a frozen archive of the engineering blog.
 
 [![fetch](https://github.com/thevibeworks/claude-code-docs/actions/workflows/fetch-claude-docs.yml/badge.svg)](https://github.com/thevibeworks/claude-code-docs/actions/workflows/fetch-claude-docs.yml)
 [![review](https://github.com/thevibeworks/claude-code-docs/actions/workflows/claude-review.yml/badge.svg)](https://github.com/thevibeworks/claude-code-docs/actions/workflows/claude-review.yml)
 [![license](https://img.shields.io/github/license/thevibeworks/claude-code-docs)](LICENSE)
-[![docs](https://img.shields.io/badge/docs-3900%2B-blue)](#content)
+[![files](https://img.shields.io/badge/files-4%2C100-blue)](#content)
 
 Clone this repo and point Claude Code at it. Every doc, tutorial, cookbook,
-skill, and engineering post Anthropic has published -- searchable, version-
-controlled, and offline.
+skill, and engineering post Anthropic publishes on a markdown surface --
+searchable, version-controlled, and offline.
 
 ## Install
 
@@ -30,17 +31,34 @@ claude "how do I set up hooks in the Agent SDK?"
 
 ## Content
 
+Counts are files on disk as of 2026-09-09; `uv run scripts/fetcher.py --tree`
+prints them live.
+
 | Source | Section | Files | What |
 |--------|---------|------:|------|
 | code.claude.com | `--section claude-code` | 198 | Claude Code + Agent SDK docs |
-| platform.claude.com | `--section api` | 1,993 | API reference, build guides |
-| claude.com/docs | `--section products` | 215 | Claude Tag, Cowork, office agents, connectors |
-| modelcontextprotocol.io | `--section mcp` | 373 | MCP spec, SDKs, governance |
-| anthropic.com | `--section engineering` | 25 | "Building Effective Agents", context engineering, tool use |
-| anthropic.com | `--section research` | 118 | Research papers |
-| anthropic.com | `--section news` | ~76 | Model releases, announcements |
-| github.com/anthropics | `--section github` | 718 | Cookbooks, skills, plugins, courses, SDK docs |
-| support.claude.com | `--section support` | 365 | Help articles |
+| platform.claude.com | `--section api` | 2,228 | API reference, build guides |
+| claude.com/docs | `--section products` | 226 | Claude Tag, Cowork, office agents, connectors |
+| modelcontextprotocol.io | `--section mcp` | 347 | MCP spec, SDKs, governance |
+| github.com/anthropics | `--section github` | 764 | Cookbooks, skills, plugins, courses, SDK docs |
+| support.claude.com | `--section support` | 372 | Help articles |
+| anthropic.com | frozen 2026-07-08 | 158 | Engineering, research, news posts -- see below |
+
+`anthropic.com` has no `--section` flag: it is HTML-only, the jina.ai proxy the
+fetcher used was removed in July 2026, and `content/blog/` has been a static
+archive since 2026-07-08. What is in it, against what anthropic.com's sitemap
+lists today:
+
+| `content/blog/` | Archived | Upstream | Coverage |
+|---|---:|---:|---:|
+| `engineering/` | 25 | 25 | complete |
+| `product/` | 4 | 4 | complete |
+| `research/` | 72 | 155 | 46% |
+| `news/` | 57 | 260 | 22% |
+
+The engineering posts -- "Building Effective Agents", context engineering, tool
+use -- are all here. Research and news are not, and will not grow until
+something converts HTML to markdown.
 
 ```
 content/
@@ -51,10 +69,11 @@ content/
   en/manage-claude/      Admin, billing, managed agents
   claude/                Product docs (Claude Tag, Cowork, office agents)
   mcp/                   MCP protocol spec + community
-  blog/
+  blog/                  frozen 2026-07-08, not refreshed
     engineering/         Building Effective Agents, context engineering, ...
     research/            Research papers
     news/                Model releases
+    product/             Product announcements
   github/
     cookbooks/           164 recipes + notebooks
     skills/              90 official Agent Skills

--- a/sources.json
+++ b/sources.json
@@ -1,13 +1,14 @@
 {
   "version": "2.0",
-  "updated": "2026-08-24",
+  "updated": "2026-09-09",
   "description": "Complete Anthropic content source registry. Discovered via robots.txt/sitemap/llms.txt probing across all known Anthropic domains, GitHub API enumeration, and package registry checks. Discovery surfaces are treated as incomplete: the fetcher also refreshes every doc already on disk, because upstream de-indexes pages it still serves.",
   "domains": {
     "anthropic.com": {
       "robots": true,
       "sitemap": true,
       "llms_txt": false,
-      "notes": "Main site: news, engineering, research"
+      "notes": "Main site: news, engineering, research. FROZEN 2026-07-08 -- HTML-only, no .md variant, and the jina.ai proxy path was removed. content/blog/ is a static archive; the fetcher skips this domain (FROZEN_DOMAINS in fetcher.py).",
+      "frozen": "2026-07-08"
     },
     "platform.claude.com": {
       "robots": true,


### PR DESCRIPTION
## The reader's first command fails

The Content table -- the first thing anyone reads after the hook -- documents three sections that do not exist:

```
| anthropic.com | `--section engineering` | 25  | ...
| anthropic.com | `--section research`    | 118 | ...
| anthropic.com | `--section news`        | ~76 | ...
```

```
$ grep -A6 '"--section"' scripts/fetcher.py
        choices=[
            "claude-code", "api", "platform", "mcp",
            "github", "support", "products", "all",
        ],
```

All three exit on an argparse error. They were real until anthropic.com was frozen on 2026-07-08 (HTML-only, no `.md` variant, jina.ai proxy path removed) and the flags went with it. The freeze **is** documented -- 45 lines below the table that still advertises the flags.

## What the archive actually holds

`content/blog/` has not changed since 2026-07-08 (`content/en/` changed today). Measured against `https://www.anthropic.com/sitemap.xml` as of 2026-09-09:

| `content/blog/` | Archived | Upstream | Coverage |
|---|---:|---:|---:|
| `engineering/` | 25 | 25 | complete |
| `product/` | 4 | 4 | complete |
| `research/` | 72 | 155 | 46% |
| `news/` | 57 | 260 | 22% |

The engineering posts are all here -- "Building Effective Agents", context engineering, tool use -- which is what the hook promises and what most readers come for. Research and news are not, and the README listed them as live sources anyway. That is now a table instead of a footnote.

## Other counts had drifted

```
section                        README   actual   delta
platform.claude.com / api        1993     2228    +235
claude.com/docs / products        215      226     +11
modelcontextprotocol.io / mcp     373      347     -26
github.com/anthropics             718      764     +46
support.claude.com                365      372      +7
code.claude.com / claude-code     198      198      ok
TOTAL                           3900+     4098
```

Both directions, so this was drift rather than a single stale edit. Nine hand-maintained numbers is a treadmill nobody wins, so they are now measured, carry an as-of date, and point at `--tree` for a live answer.

"12 sources" matched nothing checkable -- not the 8 domains in `sources.json`, not its 21 source groups, not the table's rows. It is now "six live sources", which is exactly what the table lists. The badge said `docs-3900+`; the archive holds 4,098 files.

## sources.json contradicted the code

`sources.json` described `anthropic.com` as "Main site: news, engineering, research" with no hint that it is frozen, while `fetcher.py` has `FROZEN_DOMAINS = {"anthropic.com"}`. The machine-readable registry said one thing and the code did another. The registry now carries the freeze date and names the constant.

Having the fetcher read `frozen` from the registry instead of hardcoding the set is the better fix -- one source of truth rather than two that agree by hand. Deliberately not in this PR: it changes behaviour on a pipeline that runs four times a day, and this PR should stay a docs change.

## Not a defect

Worth saying plainly, since the audit that found this started from the other hypothesis: the freeze is not a silent failure. `fetcher.py` prints `anthropic.com blog: frozen archive (not fetched)` on every run, `tombstones.json` explains why dead URLs stay, and `--section all` reports `success_rate: 100.0` on 4,022 items honestly, because the frozen domain is excluded by design rather than failing quietly. The reason still holds too: `www.anthropic.com/llms.txt` and `.../building-effective-agents.md` both 404 today. The problem was only that the README's front matter sold something the tool no longer does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
